### PR TITLE
feat: 날짜별 사진 및 업로드 개수 조회 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ repositories {
 dependencies {
     implementation 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -39,6 +40,9 @@ dependencies {
 
     implementation 'software.amazon.awssdk:s3:2.17.95'
     implementation 'com.amazonaws:aws-java-sdk-s3:1.12.232'
+
+    implementation 'org.mapstruct:mapstruct:1.5.3.Final'
+    annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.3.Final'
 }
 
 tasks.named('test') {

--- a/src/main/java/leets/memoriessquare/domain/photo/presentation/PhotoController.java
+++ b/src/main/java/leets/memoriessquare/domain/photo/presentation/PhotoController.java
@@ -10,12 +10,11 @@ import leets.memoriessquare.domain.photo.presentation.dto.PhotoDTO;
 import leets.memoriessquare.domain.photo.presentation.dto.PhotoWithDateDTO;
 import leets.memoriessquare.domain.photo.presentation.dto.UploadPhotoResponse;
 import leets.memoriessquare.domain.photo.usecase.CropPhoto;
-import leets.memoriessquare.domain.photo.usecase.GetPhotoByDate;
+import leets.memoriessquare.domain.photo.usecase.GetPhotosByDate;
 import leets.memoriessquare.domain.photo.usecase.UploadPhoto;
 import leets.memoriessquare.global.error.ErrorResponse;
 import leets.memoriessquare.global.oauth.OAuthDetails;
 import lombok.RequiredArgsConstructor;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -33,7 +32,7 @@ import java.util.Objects;
 public class PhotoController {
     private final UploadPhoto uploadPhoto;
     private final CropPhoto cropPhoto;
-    private final GetPhotoByDate getPhotoByDate;
+    private final GetPhotosByDate getPhotoByDate;
 
     @Operation(summary = "사진 업로드", description = "새로운 사진을 업로드합니다.")
     @ApiResponses({

--- a/src/main/java/leets/memoriessquare/domain/photo/presentation/PhotoController.java
+++ b/src/main/java/leets/memoriessquare/domain/photo/presentation/PhotoController.java
@@ -7,18 +7,24 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import leets.memoriessquare.domain.photo.exception.MimeTypeIsNotImageException;
 import leets.memoriessquare.domain.photo.presentation.dto.PhotoDTO;
+import leets.memoriessquare.domain.photo.presentation.dto.PhotoWithDateDTO;
 import leets.memoriessquare.domain.photo.presentation.dto.UploadPhotoResponse;
 import leets.memoriessquare.domain.photo.usecase.CropPhoto;
+import leets.memoriessquare.domain.photo.usecase.GetPhotoByDate;
 import leets.memoriessquare.domain.photo.usecase.UploadPhoto;
 import leets.memoriessquare.global.error.ErrorResponse;
 import leets.memoriessquare.global.oauth.OAuthDetails;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
 import java.util.Objects;
 
 @RestController
@@ -27,6 +33,7 @@ import java.util.Objects;
 public class PhotoController {
     private final UploadPhoto uploadPhoto;
     private final CropPhoto cropPhoto;
+    private final GetPhotoByDate getPhotoByDate;
 
     @Operation(summary = "사진 업로드", description = "새로운 사진을 업로드합니다.")
     @ApiResponses({
@@ -44,5 +51,18 @@ public class PhotoController {
         PhotoDTO photoDTO = uploadPhoto.execute(file, auth.getId());
         PhotoDTO croppedPhotoDTO = cropPhoto.execute(file, auth.getId(), photoDTO.getId());
         return new UploadPhotoResponse(photoDTO, croppedPhotoDTO);
+    }
+
+    @Operation(summary = "날짜별 사진 가져오기", description = "특정 날짜에 올린 사진을 모두 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @GetMapping("/date")
+    public List<PhotoWithDateDTO> getPhotoByDateApi(@AuthenticationPrincipal OAuthDetails auth, @RequestParam String date) {
+        LocalDate localDate = LocalDate.parse(date, DateTimeFormatter.ISO_DATE);
+        return getPhotoByDate.execute(auth.getId(), localDate);
     }
 }

--- a/src/main/java/leets/memoriessquare/domain/photo/presentation/dto/CountPhotoResponse.java
+++ b/src/main/java/leets/memoriessquare/domain/photo/presentation/dto/CountPhotoResponse.java
@@ -1,0 +1,12 @@
+package leets.memoriessquare.domain.photo.presentation.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+@AllArgsConstructor
+public class CountPhotoResponse {
+    private final Map<String, Long> count;
+}

--- a/src/main/java/leets/memoriessquare/domain/photo/presentation/dto/PhotoDTO.java
+++ b/src/main/java/leets/memoriessquare/domain/photo/presentation/dto/PhotoDTO.java
@@ -9,7 +9,7 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class PhotoDTO {
     private final UUID id;
-    private final String userId;
+    private final UUID userId;
     private final String imageUrl;
     private final boolean isCrop;
 }

--- a/src/main/java/leets/memoriessquare/domain/photo/presentation/dto/PhotoWithDateDTO.java
+++ b/src/main/java/leets/memoriessquare/domain/photo/presentation/dto/PhotoWithDateDTO.java
@@ -13,6 +13,7 @@ public class PhotoWithDateDTO {
     private final UUID userId;
     private final String imageUrl;
     private final boolean isCrop;
+    private final UUID originalPhotoId;
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
 }

--- a/src/main/java/leets/memoriessquare/domain/photo/presentation/dto/PhotoWithDateDTO.java
+++ b/src/main/java/leets/memoriessquare/domain/photo/presentation/dto/PhotoWithDateDTO.java
@@ -1,0 +1,18 @@
+package leets.memoriessquare.domain.photo.presentation.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@RequiredArgsConstructor
+public class PhotoWithDateDTO {
+    private final UUID id;
+    private final UUID userId;
+    private final String imageUrl;
+    private final boolean isCrop;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+}

--- a/src/main/java/leets/memoriessquare/domain/photo/presentation/mapper/PhotoMapper.java
+++ b/src/main/java/leets/memoriessquare/domain/photo/presentation/mapper/PhotoMapper.java
@@ -1,0 +1,12 @@
+package leets.memoriessquare.domain.photo.presentation.mapper;
+
+import leets.memoriessquare.domain.photo.domain.Photo;
+import leets.memoriessquare.domain.photo.presentation.dto.PhotoWithDateDTO;
+import org.mapstruct.*;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface PhotoMapper {
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    @Mapping(source = "crop", target = "isCrop")
+    PhotoWithDateDTO mappingPhototoDto(Photo photo);
+}

--- a/src/main/java/leets/memoriessquare/domain/photo/repository/PhotoRepository.java
+++ b/src/main/java/leets/memoriessquare/domain/photo/repository/PhotoRepository.java
@@ -3,10 +3,10 @@ package leets.memoriessquare.domain.photo.repository;
 import leets.memoriessquare.domain.photo.domain.Photo;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
 public interface PhotoRepository extends JpaRepository<Photo, UUID> {
-    List<Photo> findAllByUser_IdAndCreatedAtOrderByCreatedAtDesc(UUID userId, LocalDate createdAt);
+    List<Photo> findAllByUser_IdAndCreatedAtBetweenOrderByCreatedAtDesc(UUID userId, LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/leets/memoriessquare/domain/photo/repository/PhotoRepository.java
+++ b/src/main/java/leets/memoriessquare/domain/photo/repository/PhotoRepository.java
@@ -2,11 +2,17 @@ package leets.memoriessquare.domain.photo.repository;
 
 import leets.memoriessquare.domain.photo.domain.Photo;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 public interface PhotoRepository extends JpaRepository<Photo, UUID> {
     List<Photo> findAllByUser_IdAndCreatedAtBetweenOrderByCreatedAtDesc(UUID userId, LocalDateTime start, LocalDateTime end);
+
+    @Query("SELECT DATE(createdAt) as date, COUNT(*) as count FROM photos WHERE user.id = :userId AND YEAR(createdAt) = :year AND MONTH(createdAt) = :month AND isCrop = false GROUP BY DATE(createdAt) ")
+    List<Map<String, Object>> countByYearAndMonth(@Param("userId") UUID userId, @Param("year") int year, @Param("month") int month);
 }

--- a/src/main/java/leets/memoriessquare/domain/photo/repository/PhotoRepository.java
+++ b/src/main/java/leets/memoriessquare/domain/photo/repository/PhotoRepository.java
@@ -1,12 +1,12 @@
 package leets.memoriessquare.domain.photo.repository;
 
 import leets.memoriessquare.domain.photo.domain.Photo;
-import leets.memoriessquare.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
 public interface PhotoRepository extends JpaRepository<Photo, UUID> {
-//    List<Photo> findByUser(User user);
+    List<Photo> findAllByUser_IdAndCreatedAtOrderByCreatedAtDesc(UUID userId, LocalDate createdAt);
 }

--- a/src/main/java/leets/memoriessquare/domain/photo/usecase/CountPhotoByDate.java
+++ b/src/main/java/leets/memoriessquare/domain/photo/usecase/CountPhotoByDate.java
@@ -1,0 +1,8 @@
+package leets.memoriessquare.domain.photo.usecase;
+
+import java.util.Map;
+import java.util.UUID;
+
+public interface CountPhotoByDate {
+    Map<String, Long> execute(UUID userId, int year, int month);
+}

--- a/src/main/java/leets/memoriessquare/domain/photo/usecase/CountPhotoByDateImpl.java
+++ b/src/main/java/leets/memoriessquare/domain/photo/usecase/CountPhotoByDateImpl.java
@@ -1,0 +1,24 @@
+package leets.memoriessquare.domain.photo.usecase;
+
+import leets.memoriessquare.domain.photo.repository.PhotoRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@Service
+public class CountPhotoByDateImpl implements CountPhotoByDate {
+    private final PhotoRepository photoRepository;
+
+    @Override
+    public Map<String, Long> execute(UUID userId, int year, int month) {
+        List<Map<String, Object>> count = photoRepository.countByYearAndMonth(userId, year, month);
+        Map<String, Long> result = new HashMap<>();
+        count.forEach(i -> result.put(i.get("date").toString(), (Long) i.get("count")));
+        return result;
+    }
+}

--- a/src/main/java/leets/memoriessquare/domain/photo/usecase/CropPhotoImpl.java
+++ b/src/main/java/leets/memoriessquare/domain/photo/usecase/CropPhotoImpl.java
@@ -54,6 +54,7 @@ public class CropPhotoImpl implements CropPhoto {
                     .user(user)
                     .imageUrl(url)
                     .originalPhoto(originalPhoto)
+                    .isCrop(true)
                     .build();
             photoRepository.save(photo);
 

--- a/src/main/java/leets/memoriessquare/domain/photo/usecase/CropPhotoImpl.java
+++ b/src/main/java/leets/memoriessquare/domain/photo/usecase/CropPhotoImpl.java
@@ -57,7 +57,7 @@ public class CropPhotoImpl implements CropPhoto {
                     .build();
             photoRepository.save(photo);
 
-            return new PhotoDTO(photo.getId(), user.getId().toString(), photo.getImageUrl(), true);
+            return new PhotoDTO(photo.getId(), user.getId(), photo.getImageUrl(), true);
         }
     }
 }

--- a/src/main/java/leets/memoriessquare/domain/photo/usecase/GetPhotoByDate.java
+++ b/src/main/java/leets/memoriessquare/domain/photo/usecase/GetPhotoByDate.java
@@ -1,0 +1,11 @@
+package leets.memoriessquare.domain.photo.usecase;
+
+import leets.memoriessquare.domain.photo.presentation.dto.PhotoWithDateDTO;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+public interface GetPhotoByDate {
+    List<PhotoWithDateDTO> execute(UUID userId, LocalDate date);
+}

--- a/src/main/java/leets/memoriessquare/domain/photo/usecase/GetPhotoByDateImpl.java
+++ b/src/main/java/leets/memoriessquare/domain/photo/usecase/GetPhotoByDateImpl.java
@@ -2,25 +2,27 @@ package leets.memoriessquare.domain.photo.usecase;
 
 import leets.memoriessquare.domain.photo.domain.Photo;
 import leets.memoriessquare.domain.photo.presentation.dto.PhotoWithDateDTO;
+import leets.memoriessquare.domain.photo.presentation.mapper.PhotoMapper;
 import leets.memoriessquare.domain.photo.repository.PhotoRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Objects;
 import java.util.UUID;
 
 @RequiredArgsConstructor
 @Service
 public class GetPhotoByDateImpl implements GetPhotoByDate {
     private final PhotoRepository photoRepository;
+    private final PhotoMapper photoMapper;
 
     @Override
     public List<PhotoWithDateDTO> execute(UUID userId, LocalDate date) {
-        List<Photo> photos = photoRepository.findAllByUser_IdAndCreatedAtBetweenOrderByCreatedAtDesc(userId, date.atTime(0, 0), date.atTime(23, 59));
-        return photos.stream().map(i ->
-                new PhotoWithDateDTO(i.getId(), i.getUser().getId(), i.getImageUrl(), i.isCrop(), Objects.requireNonNullElse(i.getOriginalPhoto().getId(), null), i.getCreatedAt(), i.getUpdatedAt())
-        ).toList();
+        List<Photo> photos = photoRepository
+                .findAllByUser_IdAndCreatedAtBetweenOrderByCreatedAtDesc(
+                        userId, date.atTime(0, 0), date.atTime(23, 59)
+                );
+        return photos.stream().map(photoMapper::mappingPhototoDto).toList();
     }
 }

--- a/src/main/java/leets/memoriessquare/domain/photo/usecase/GetPhotoByDateImpl.java
+++ b/src/main/java/leets/memoriessquare/domain/photo/usecase/GetPhotoByDateImpl.java
@@ -13,7 +13,7 @@ import java.util.UUID;
 
 @RequiredArgsConstructor
 @Service
-public class GetPhotoByDateImpl implements GetPhotoByDate {
+public class GetPhotoByDateImpl implements GetPhotosByDate {
     private final PhotoRepository photoRepository;
     private final PhotoMapper photoMapper;
 

--- a/src/main/java/leets/memoriessquare/domain/photo/usecase/GetPhotoByDateImpl.java
+++ b/src/main/java/leets/memoriessquare/domain/photo/usecase/GetPhotoByDateImpl.java
@@ -1,0 +1,25 @@
+package leets.memoriessquare.domain.photo.usecase;
+
+import leets.memoriessquare.domain.photo.domain.Photo;
+import leets.memoriessquare.domain.photo.presentation.dto.PhotoWithDateDTO;
+import leets.memoriessquare.domain.photo.repository.PhotoRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@Service
+public class GetPhotoByDateImpl implements GetPhotoByDate {
+    private final PhotoRepository photoRepository;
+
+    @Override
+    public List<PhotoWithDateDTO> execute(UUID userId, LocalDate date) {
+        List<Photo> photos = photoRepository.findAllByUser_IdAndCreatedAtOrderByCreatedAtDesc(userId, date);
+        return photos.stream().map(i ->
+                new PhotoWithDateDTO(i.getId(), i.getUser().getId(), i.getImageUrl(), i.isCrop(), i.getCreatedAt(), i.getUpdatedAt())
+        ).toList();
+    }
+}

--- a/src/main/java/leets/memoriessquare/domain/photo/usecase/GetPhotoByDateImpl.java
+++ b/src/main/java/leets/memoriessquare/domain/photo/usecase/GetPhotoByDateImpl.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
 @RequiredArgsConstructor
@@ -17,9 +18,9 @@ public class GetPhotoByDateImpl implements GetPhotoByDate {
 
     @Override
     public List<PhotoWithDateDTO> execute(UUID userId, LocalDate date) {
-        List<Photo> photos = photoRepository.findAllByUser_IdAndCreatedAtOrderByCreatedAtDesc(userId, date);
+        List<Photo> photos = photoRepository.findAllByUser_IdAndCreatedAtBetweenOrderByCreatedAtDesc(userId, date.atTime(0, 0), date.atTime(23, 59));
         return photos.stream().map(i ->
-                new PhotoWithDateDTO(i.getId(), i.getUser().getId(), i.getImageUrl(), i.isCrop(), i.getCreatedAt(), i.getUpdatedAt())
+                new PhotoWithDateDTO(i.getId(), i.getUser().getId(), i.getImageUrl(), i.isCrop(), Objects.requireNonNullElse(i.getOriginalPhoto().getId(), null), i.getCreatedAt(), i.getUpdatedAt())
         ).toList();
     }
 }

--- a/src/main/java/leets/memoriessquare/domain/photo/usecase/GetPhotosByDate.java
+++ b/src/main/java/leets/memoriessquare/domain/photo/usecase/GetPhotosByDate.java
@@ -6,6 +6,6 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
-public interface GetPhotoByDate {
+public interface GetPhotosByDate {
     List<PhotoWithDateDTO> execute(UUID userId, LocalDate date);
 }

--- a/src/main/java/leets/memoriessquare/domain/photo/usecase/UploadPhotoImpl.java
+++ b/src/main/java/leets/memoriessquare/domain/photo/usecase/UploadPhotoImpl.java
@@ -36,6 +36,6 @@ public class UploadPhotoImpl implements UploadPhoto {
 
         photoRepository.save(photo);
 
-        return new PhotoDTO(photo.getId(), user.getId().toString(), photo.getImageUrl(), false);
+        return new PhotoDTO(photo.getId(), user.getId(), photo.getImageUrl(), false);
     }
 }

--- a/src/main/java/leets/memoriessquare/global/security/WebSecurityConfig.java
+++ b/src/main/java/leets/memoriessquare/global/security/WebSecurityConfig.java
@@ -50,7 +50,7 @@ public class WebSecurityConfig {
                 .requestMatchers("/v3/api-docs/**", "/swagger-ui/**").permitAll()
 
                 .requestMatchers("/user/**").hasAuthority(AuthRole.ROLE_USER.getRole())
-                .requestMatchers("/photo/upload/**").hasAuthority(AuthRole.ROLE_USER.getRole())
+                .requestMatchers("/photo/**").hasAuthority(AuthRole.ROLE_USER.getRole())
 
                 .requestMatchers("/oauth/**").permitAll()
 


### PR DESCRIPTION
## 추가된 점 또는 변경된 점
- 날짜별 사진 조회 API를 구현했습니다. (`GET /photo/date`)
  - `date` 쿼리로 특정 날짜를 조회할 수 있습니다. (예: `/photo/date?date=2023-07-01`)
- 날짜별 사진 개수 API를 구현했습니다. (`GET /photo/count`)
- 위 모든 API는 로그인한 유저 기준으로 가져옵니다.

## 주의사항 및 참고사항